### PR TITLE
Support for iOS 16

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "Toast",
     defaultLocalization: "en",
-    platforms: [.iOS(.v17), .macOS(.v14)],
+    platforms: [.iOS(.v16), .macOS(.v14)],
     products: [
         .library(
             name: "Toast",

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 | Platform | Minimum Version |
 |----------|-----------------|
-| iOS      | 17.0            |
+| iOS      | 16.0            |
 | macOS    | 14.0            |
 
 ## Get Started

--- a/Sources/Toast/Modifiers/ToastModifier.swift
+++ b/Sources/Toast/Modifiers/ToastModifier.swift
@@ -73,12 +73,6 @@ struct ToastModifier<TrailingView: View>: ViewModifier {
         dismissToastAnimation()
     }
 
-    private func onChangeToast(_ oldToast: Toast?, _ newToast: Toast?) {
-        if newToast != nil {
-            presentToastAnimation()
-        }
-    }
-
     private func presentToastAnimation() {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
             withAnimation(.spring()) {
@@ -108,7 +102,11 @@ struct ToastModifier<TrailingView: View>: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .onChange(of: toast, onChangeToast)
+            .onChange(of: toast) { newToast in
+                if newToast != nil {
+                    presentToastAnimation()
+                }
+            }
             .overlay(
                 alignment: edge.alignment,
                 content: toastView

--- a/Sources/Toast/Views/ToastMessageView.swift
+++ b/Sources/Toast/Views/ToastMessageView.swift
@@ -78,9 +78,11 @@ struct ToastMessageView<TrailingView: View>: View {
 
     private var backgroundView: some View {
         RoundedRectangle(cornerRadius: 10)
-            .fill(.background.secondary)
             .fill(toast.color.opacity(0.08))
-            .stroke(toast.color, lineWidth: 2)
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(toast.color, lineWidth: 2) // Borde encima
+            )
     }
 }
 

--- a/Sources/Toast/Views/ToastMessageView.swift
+++ b/Sources/Toast/Views/ToastMessageView.swift
@@ -81,7 +81,7 @@ struct ToastMessageView<TrailingView: View>: View {
             .fill(toast.color.opacity(0.08))
             .overlay(
                 RoundedRectangle(cornerRadius: 10)
-                    .stroke(toast.color, lineWidth: 2) // Borde encima
+                    .stroke(toast.color, lineWidth: 2)
             )
     }
 }


### PR DESCRIPTION
This update replaces some SwiftUI modifiers with alternatives supported in iOS 16. 
All changes preserve compatibility with iOS 17 and above.


| Before | After |
| ------ | ------|
| <img width="331" alt="Screenshot 2025-05-15 at 2 32 49 p m" src="https://github.com/user-attachments/assets/9c39423d-63db-416f-91c0-d8c43f0fc664" /> | <img width="330" alt="Screenshot 2025-05-15 at 2 30 59 p m" src="https://github.com/user-attachments/assets/85e347da-e9f2-4efc-8d68-dde5775417a2" /> | 
| <img width="344" alt="Screenshot 2025-05-15 at 2 34 13 p m" src="https://github.com/user-attachments/assets/007e7989-7c98-46f6-962c-0d9058dad02e" /> | <img width="350" alt="Screenshot 2025-05-15 at 2 34 38 p m" src="https://github.com/user-attachments/assets/29296b61-2b0a-4d69-ab77-294ae6bab801" /> |


