### PR TITLE
Rename package branding to SwiftUI-Toast

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "Toast",
+    name: "SwiftUI-Toast",
     defaultLocalization: "en",
     platforms: [.iOS(.v16), .macOS(.v14)],
     products: [

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Toast
+# SwiftUI-Toast
 
 ## Description
-`Toast` is a lightweight SwiftUI library that provides a simple way to display toast messages.
+`SwiftUI-Toast` is a lightweight SwiftUI library that provides a simple way to display toast messages.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- rename the Swift package manifest to use the SwiftUI-Toast branding requested for the repository
- update the README heading and description so the documentation surfaces the SwiftUI-Toast name while keeping the module import examples intact

## Testing
- `swift test` *(fails: SwiftUI is unavailable on this Linux toolchain, so the module cannot build here)*
- `pre-commit run --all-files` *(fails: pre-commit is not installed and the environment blocks installing it via pip)*

------
https://chatgpt.com/codex/tasks/task_e_68fd90877b548325bf5ae187cebbcd86